### PR TITLE
Added remove reaction functionality to RemindMe

### DIFF
--- a/general/remind_me/cog.py
+++ b/general/remind_me/cog.py
@@ -25,6 +25,7 @@ class RemindMeCog(Cog, name="RemindMe"):
         if message.attachments:
             try:
                 await member.send("\n".join(attachment.url for attachment in message.attachments))
+                await message.remove_reaction(emoji, member)
             except Forbidden:
                 await message.remove_reaction(emoji, member)
                 return
@@ -34,5 +35,6 @@ class RemindMeCog(Cog, name="RemindMe"):
         if message.content or embed:
             try:
                 await member.send(message.content, embed=embed)
+                await message.remove_reaction(emoji, member)
             except Forbidden:
                 await message.remove_reaction(emoji, member)


### PR DESCRIPTION
A reaction should always be removed. It offers no value, leaving a "dead reaction" on a message, when the reaction is just for personal use. (It offers no valuable information to others)
