### PR TITLE
Fixed Logger Edit Distance Bug

### DIFF
--- a/contributor.py
+++ b/contributor.py
@@ -9,3 +9,4 @@ class Contributor(ContributorBase):
     Anorak = (202370816384565248, "MDQ6VXNlcjMyNDg3NzYw")
     LoC = (519559136237715486, "MDQ6VXNlcjY0MDk1MjUz")
     Tristan = (277069925678317568, "MDQ6VXNlcjQ1MzMwNjY3")
+    Tert0 = (621330363167539210, "MDQ6VXNlcjYyMDM2NDY0")

--- a/moderation/logging/cog.py
+++ b/moderation/logging/cog.py
@@ -173,7 +173,7 @@ class LoggingCog(Cog, name="Logging"):
         old_message = await redis.get(key := f"little_diff_message_edit:{before.id}") or before.content
         if calculate_edit_distance(old_message, after.content) < mindiff:
             if not await redis.exists(key):
-                await redis.setex(key, 1000 * 60 * 60 * 24, before.content)
+                await redis.setex(key, 60 * 60 * 24, before.content)
             return
         if (edit_channel := await self.get_logging_channel(LoggingSettings.edit_channel)) is None:
             return

--- a/moderation/logging/cog.py
+++ b/moderation/logging/cog.py
@@ -174,7 +174,7 @@ class LoggingCog(Cog, name="Logging"):
             old_message = before.content
         if calculate_edit_distance(old_message, after.content) < mindiff:
             if not await redis.exists(f"little_diff_message_edit:{after.id}"):
-                await redis.pset(f"little_diff_message_edit:{before.id}", before.content, 1000 * 60 * 60 * 24)
+                await redis.setex(f"little_diff_message_edit:{before.id}", 1000 * 60 * 60 * 24, before.content)
             return
         if (edit_channel := await self.get_logging_channel(LoggingSettings.edit_channel)) is None:
             return

--- a/moderation/logging/cog.py
+++ b/moderation/logging/cog.py
@@ -174,7 +174,7 @@ class LoggingCog(Cog, name="Logging"):
             old_message = before.content
         if calculate_edit_distance(old_message, after.content) < mindiff:
             if not await redis.exists(f"little_diff_message_edit:{after.id}"):
-                await redis.set(f"little_diff_message_edit:{before.id}", before.content)
+                await redis.pset(f"little_diff_message_edit:{before.id}", before.content, 1000 * 60 * 60 * 24)
             return
         if (edit_channel := await self.get_logging_channel(LoggingSettings.edit_channel)) is None:
             return
@@ -212,6 +212,7 @@ class LoggingCog(Cog, name="Logging"):
             return
         if (delete_channel := await self.get_logging_channel(LoggingSettings.delete_channel)) is None:
             return
+        await redis.delete(f"little_diff_message_edit:{message.id}")
         if await is_logging_channel(message.channel):
             return
         if await LogExclude.exists(message.channel.id):
@@ -238,6 +239,7 @@ class LoggingCog(Cog, name="Logging"):
             return
         if (delete_channel := await self.get_logging_channel(LoggingSettings.delete_channel)) is None:
             return
+        await redis.delete(f"little_diff_message_edit:{event.message_id}")
         if await LogExclude.exists(event.channel_id):
             return
 


### PR DESCRIPTION
**Description**
Fixed Logger Edit Distance Bug

It was possible to edit a message in little steps (e.g. 1 char) without the bot logs that


