### PR TITLE
Add other git servers to AdventOfCode cog

### DIFF
--- a/integrations/adventofcode/cog.py
+++ b/integrations/adventofcode/cog.py
@@ -157,13 +157,16 @@ def escape_aoc_name(name: Optional[str]) -> str:
 def get_git_repo(url: str) -> Optional[str]:
     servers = [
         (
-            r"^(https?://)?gitlab.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$", "https://gitlab.com/api/v4/projects/{}%2F{}"
+            r"^(https?://)?gitlab.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$",
+            "https://gitlab.com/api/v4/projects/{}%2F{}",
         ),
         (
-            r"^(https?://)?gitea.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$", "https://gitea.com/api/v1/repos/{user}/{repo}"
+            r"^(https?://)?gitea.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$",
+            "https://gitea.com/api/v1/repos/{user}/{repo}",
         ),
         (
-            r"^(https?://)?github.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$", "https://api.github.com/repos/{user}/{repo}"
+            r"^(https?://)?github.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$",
+            "https://api.github.com/repos/{user}/{repo}",
         ),
     ]
 
@@ -183,10 +186,10 @@ def get_git_repo(url: str) -> Optional[str]:
 # Alternative parsing facility
 def parse_git_url(url: str) -> tuple[str, str]:
     patterns = [
-            r"^https://gitlab.com/([^/]+)/([^/]+).*",
-            r"^https://gitea.com/([^/]+)/([^/]+).*",
-            r"^https://github.com/([^/]+)/([^/]+).*"
-        ]
+        r"^https://gitlab.com/([^/]+)/([^/]+).*",
+        r"^https://gitea.com/([^/]+)/([^/]+).*",
+        r"^https://github.com/([^/]+)/([^/]+).*",
+    ]
     for pattern in patterns:
         match = re.match(pattern, url)
         if match is not None:
@@ -551,7 +554,7 @@ class AdventOfCodeCog(Cog, name="Advent of Code Integration"):
         if not await db.get(AOCLink, discord_id=ctx.author.id):
             raise CommandError(t.not_verified)
 
-        url: Optional[str] = get_github_repo(url)
+        url: Optional[str] = get_git_repo(url)
         if not url or len(url) > 128:
             raise CommandError(t.invalid_url)
 

--- a/integrations/adventofcode/cog.py
+++ b/integrations/adventofcode/cog.py
@@ -178,6 +178,14 @@ def get_github_repo(url: str) -> Optional[str]:
         r"^(https?://)?github.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$",
         "https://api.github.com/repos/{user}/{repo}")
 
+# Alternative parsing facility
+def parse_url(url: str) -> tuple[str, str]:
+    for pattern in [r"^https://gitlab.com/([^/]+)/([^/]+).*", r"^https://gitea.com/([^/]+)/([^/]+).*", r"^https://github.com/([^/]+)/([^/]+).*"]:
+        match = re.match(pattern, url)
+        if match is not None:
+            user, repo = match.groups()
+            return user, repo
+    return "", "" # TODO how handle error
 
 def parse_git_url(url: str, pattern: str) -> tuple[str, str]:
     user, repo = re.match(pattern, url).groups()

--- a/integrations/adventofcode/cog.py
+++ b/integrations/adventofcode/cog.py
@@ -158,7 +158,7 @@ def get_git_repo(url: str) -> Optional[str]:
     servers = [
         (
             r"^(https?://)?gitlab.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$",
-            "https://gitlab.com/api/v4/projects/{}%2F{}",
+            "https://gitlab.com/api/v4/projects/{user}%2F{repo}",
         ),
         (
             r"^(https?://)?gitea.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$",

--- a/integrations/adventofcode/cog.py
+++ b/integrations/adventofcode/cog.py
@@ -154,13 +154,13 @@ def escape_aoc_name(name: Optional[str]) -> str:
 
 # Alternative get facility
 def get_git_repo(url: str) -> Optional[str]:
-    l = [
+    servers = [
             (r"^(https?://)?gitlab.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$", "https://gitlab.com/api/v4/projects/{}%2F{}"),
             (r"^(https?://)?gitea.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$", "https://gitea.com/api/v1/repos/{user}/{repo}"),
             (r"^(https?://)?github.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$", "https://api.github.com/repos/{user}/{repo}")
         ]
 
-    for pattern, api in l:
+    for pattern, api in servers:
         if not (match := re.match(pattern, url)):
             continue
         _, user, repo, path = match.groups()
@@ -204,7 +204,12 @@ def get_github_repo(url: str) -> Optional[str]:
 
 # Alternative parsing facility
 def parse_git_url(url: str) -> tuple[str, str]:
-    for pattern in [r"^https://gitlab.com/([^/]+)/([^/]+).*", r"^https://gitea.com/([^/]+)/([^/]+).*", r"^https://github.com/([^/]+)/([^/]+).*"]:
+    patterns = [
+            r"^https://gitlab.com/([^/]+)/([^/]+).*",
+            r"^https://gitea.com/([^/]+)/([^/]+).*",
+            r"^https://github.com/([^/]+)/([^/]+).*"
+        ]
+    for pattern in patterns:
         match = re.match(pattern, url)
         if match is not None:
             user, repo = match.groups()

--- a/integrations/adventofcode/cog.py
+++ b/integrations/adventofcode/cog.py
@@ -153,7 +153,7 @@ def escape_aoc_name(name: Optional[str]) -> str:
     return "".join(c for c in name if c.isalnum() or c in " _-") if name else ""
 
 # Alternative get facility
-def get_repo(url: str) -> Optional[str]:
+def get_git_repo(url: str) -> Optional[str]:
     l = [
             (r"^(https?://)?gitlab.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$", "https://gitlab.com/api/v4/projects/{}%2F{}"),
             (r"^(https?://)?gitea.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$", "https://gitea.com/api/v1/repos/{user}/{repo}"),
@@ -173,7 +173,7 @@ def get_repo(url: str) -> Optional[str]:
     return None
 
 # TODO remove
-def get_git_repo(url: str, pattern: str, api: str) -> Optional[str]:
+def get_repo(url: str, pattern: str, api: str) -> Optional[str]:
     if not (match := re.match(pattern, url)):
         return None
     _, user, repo, path = match.groups()
@@ -203,7 +203,7 @@ def get_github_repo(url: str) -> Optional[str]:
         "https://api.github.com/repos/{user}/{repo}")
 
 # Alternative parsing facility
-def parse_url(url: str) -> tuple[str, str]:
+def parse_git_url(url: str) -> tuple[str, str]:
     for pattern in [r"^https://gitlab.com/([^/]+)/([^/]+).*", r"^https://gitea.com/([^/]+)/([^/]+).*", r"^https://github.com/([^/]+)/([^/]+).*"]:
         match = re.match(pattern, url)
         if match is not None:
@@ -212,7 +212,7 @@ def parse_url(url: str) -> tuple[str, str]:
     return "", "" # TODO how handle error
 
 # TODO remove
-def parse_git_url(url: str, pattern: str) -> tuple[str, str]:
+def parse_url(url: str, pattern: str) -> tuple[str, str]:
     user, repo = re.match(pattern, url).groups()
     return user, repo
 
@@ -395,7 +395,7 @@ class AdventOfCodeCog(Cog, name="Advent of Code Integration"):
         embed.add_field(name=":chart_with_upwards_trend: Progress", value=progress, inline=True)
 
         if link and link.solutions:
-            user, repo = parse_github_url(link.solutions)
+            user, repo = parse_git_url(link.solutions)
             embed.add_field(name=":package: Solutions", value=f"[[{user}/{repo}]]({link.solutions})", inline=True)
 
         embed.add_field(name=":star: Stars", value=aoc_member["stars"], inline=True)
@@ -620,7 +620,7 @@ class AdventOfCodeCog(Cog, name="Advent of Code Integration"):
             if not link.solutions or link.aoc_id not in members:
                 continue
 
-            user, repo = parse_github_url(link.solutions)
+            user, repo = parse_git_url(link.solutions)
             out.append(f"<@{link.discord_id}> ({members[link.aoc_id]['name']}): [[{user}/{repo}]]({link.solutions})")
 
         if not out:

--- a/integrations/adventofcode/cog.py
+++ b/integrations/adventofcode/cog.py
@@ -172,6 +172,7 @@ def get_repo(url: str) -> Optional[str]:
         return url
     return None
 
+# TODO remove
 def get_git_repo(url: str, pattern: str, api: str) -> Optional[str]:
     if not (match := re.match(pattern, url)):
         return None
@@ -183,16 +184,19 @@ def get_git_repo(url: str, pattern: str, api: str) -> Optional[str]:
         return None
     return url
 
+# TODO remove
 def get_gitlab_repo(url: str) -> Optional[str]:
     return get_git_repo(url,
             r"^(https?://)?gitlab.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$",
             "https://gitlab.com/api/v4/projects/{}%2F{}")
 
+# TODO remove
 def get_gitea_repo(url: str) -> Optional[str]:
     return get_git_repo(url,
         r"^(https?://)?gitea.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$",
         "https://gitea.com/api/v1/repos/{user}/{repo}")
 
+# TODO remove
 def get_github_repo(url: str) -> Optional[str]:
     return get_git_repo(url,
         r"^(https?://)?github.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$",
@@ -207,16 +211,20 @@ def parse_url(url: str) -> tuple[str, str]:
             return user, repo
     return "", "" # TODO how handle error
 
+# TODO remove
 def parse_git_url(url: str, pattern: str) -> tuple[str, str]:
     user, repo = re.match(pattern, url).groups()
     return user, repo
 
+# TODO remove
 def parse_gitlab_url(url: str) -> tuple[str, str]:
     return parse_git_url(url, r"^https://gitlab.com/([^/]+)/([^/]+).*")
 
+# TODO remove
 def parse_gitea_url(url: str) -> tuple[str, str]:
     return parse_git_url(url, r"^https://gitea.com/([^/]+)/([^/]+).*")
 
+# TODO remove
 def parse_github_url(url: str) -> tuple[str, str]:
     return parse_git_url(url, r"^https://github.com/([^/]+)/([^/]+).*")
 

--- a/integrations/adventofcode/cog.py
+++ b/integrations/adventofcode/cog.py
@@ -174,7 +174,7 @@ def get_git_repo(url: str) -> Optional[str]:
         if not (match := re.match(pattern, url)):
             continue
         _, user, repo, path = match.groups()
-        if not (response := requests.get(api.format(user, repo))).ok:
+        if not (response := requests.get(api.format(user=user, repo=repo))).ok:
             continue  # TODO or exit here
         url = response.json()["html_url"] + (path or "")
         if not requests.head(url).ok:

--- a/integrations/adventofcode/cog.py
+++ b/integrations/adventofcode/cog.py
@@ -152,55 +152,33 @@ def make_member_stats(member: dict) -> tuple[int, list[str]]:
 def escape_aoc_name(name: Optional[str]) -> str:
     return "".join(c for c in name if c.isalnum() or c in " _-") if name else ""
 
+
 # Alternative get facility
 def get_git_repo(url: str) -> Optional[str]:
     servers = [
-            (r"^(https?://)?gitlab.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$", "https://gitlab.com/api/v4/projects/{}%2F{}"),
-            (r"^(https?://)?gitea.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$", "https://gitea.com/api/v1/repos/{user}/{repo}"),
-            (r"^(https?://)?github.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$", "https://api.github.com/repos/{user}/{repo}")
-        ]
+        (
+            r"^(https?://)?gitlab.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$", "https://gitlab.com/api/v4/projects/{}%2F{}"
+        ),
+        (
+            r"^(https?://)?gitea.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$", "https://gitea.com/api/v1/repos/{user}/{repo}"
+        ),
+        (
+            r"^(https?://)?github.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$", "https://api.github.com/repos/{user}/{repo}"
+        ),
+    ]
 
     for pattern, api in servers:
         if not (match := re.match(pattern, url)):
             continue
         _, user, repo, path = match.groups()
         if not (response := requests.get(api.format(user, repo))).ok:
-            continue # TODO or exit here
+            continue  # TODO or exit here
         url = response.json()["html_url"] + (path or "")
         if not requests.head(url).ok:
-            continue # TODO or exit here
+            continue  # TODO or exit here
         return url
     return None
 
-# TODO remove
-def get_repo(url: str, pattern: str, api: str) -> Optional[str]:
-    if not (match := re.match(pattern, url)):
-        return None
-    _, user, repo, path = match.groups()
-    if not (response := requests.get(api.format(user, repo))).ok:
-        return None
-    url = response.json()["html_url"] + (path or "")
-    if not requests.head(url).ok:
-        return None
-    return url
-
-# TODO remove
-def get_gitlab_repo(url: str) -> Optional[str]:
-    return get_git_repo(url,
-            r"^(https?://)?gitlab.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$",
-            "https://gitlab.com/api/v4/projects/{}%2F{}")
-
-# TODO remove
-def get_gitea_repo(url: str) -> Optional[str]:
-    return get_git_repo(url,
-        r"^(https?://)?gitea.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$",
-        "https://gitea.com/api/v1/repos/{user}/{repo}")
-
-# TODO remove
-def get_github_repo(url: str) -> Optional[str]:
-    return get_git_repo(url,
-        r"^(https?://)?github.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$",
-        "https://api.github.com/repos/{user}/{repo}")
 
 # Alternative parsing facility
 def parse_git_url(url: str) -> tuple[str, str]:
@@ -214,24 +192,7 @@ def parse_git_url(url: str) -> tuple[str, str]:
         if match is not None:
             user, repo = match.groups()
             return user, repo
-    return "", "" # TODO how handle error
-
-# TODO remove
-def parse_url(url: str, pattern: str) -> tuple[str, str]:
-    user, repo = re.match(pattern, url).groups()
-    return user, repo
-
-# TODO remove
-def parse_gitlab_url(url: str) -> tuple[str, str]:
-    return parse_git_url(url, r"^https://gitlab.com/([^/]+)/([^/]+).*")
-
-# TODO remove
-def parse_gitea_url(url: str) -> tuple[str, str]:
-    return parse_git_url(url, r"^https://gitea.com/([^/]+)/([^/]+).*")
-
-# TODO remove
-def parse_github_url(url: str) -> tuple[str, str]:
-    return parse_git_url(url, r"^https://github.com/([^/]+)/([^/]+).*")
+    return "", ""  # TODO how handle error
 
 
 class AdventOfCodeCog(Cog, name="Advent of Code Integration"):

--- a/integrations/adventofcode/cog.py
+++ b/integrations/adventofcode/cog.py
@@ -159,24 +159,27 @@ def get_git_repo(url: str) -> Optional[str]:
         (
             r"^(https?://)?gitlab.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$",
             "https://gitlab.com/api/v4/projects/{user}%2F{repo}",
+            "web_url",
         ),
         (
             r"^(https?://)?gitea.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$",
             "https://gitea.com/api/v1/repos/{user}/{repo}",
+            "html_url",
         ),
         (
             r"^(https?://)?github.com/([a-zA-Z0-9.\-_]+)/([a-zA-Z0-9.\-_]+)(/.*)?$",
             "https://api.github.com/repos/{user}/{repo}",
+            "html_url",
         ),
     ]
 
-    for pattern, api in servers:
+    for pattern, api, web_url_key in servers:
         if not (match := re.match(pattern, url)):
             continue
         _, user, repo, path = match.groups()
         if not (response := requests.get(api.format(user=user, repo=repo))).ok:
             continue  # TODO or exit here
-        url = response.json()["html_url"] + (path or "")
+        url = response.json()[web_url_key] + (path or "")
         if not requests.head(url).ok:
             continue  # TODO or exit here
         return url

--- a/integrations/adventofcode/cog.py
+++ b/integrations/adventofcode/cog.py
@@ -178,10 +178,10 @@ def get_git_repo(url: str) -> Optional[str]:
             continue
         _, user, repo, path = match.groups()
         if not (response := requests.get(api.format(user=user, repo=repo))).ok:
-            continue  # TODO or exit here
+            break
         url = response.json()[web_url_key] + (path or "")
         if not requests.head(url).ok:
-            continue  # TODO or exit here
+            break
         return url
     return None
 


### PR DESCRIPTION
**Description**
With this changes other git remove servers than `github` can be added to AdventOfCode.

Some of the functions are present only for the purpose of packing the `get` and the `parse` functionality into one single function isn't desired for some coding style reason (even though I wouldn't see one). These functions are marked as `TODO remove`.

**Additional Notes**
Please do not merge directly, because honestly since I don't know how to set this whole thing up with the database and so one, this code is **untested**. So you'll have to test this your own.